### PR TITLE
fix Eclipse classpath, invoke pre- and post-frame hooks in non-realtime mode

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,18 +2,18 @@
 <classpath>
 	<classpathentry kind="src" path="tutorial"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
-	<classpathentry kind="lib" path="library/beads.jar"/>
-	<classpathentry kind="lib" path="library/beads-io.jar"/>
-	<classpathentry kind="lib" path="library/jarjar-1.0.jar"/>
-	<classpathentry kind="lib" path="library/jl1.0.1.jar"/>
-	<classpathentry kind="lib" path="library/jna.jar"/>
-	<classpathentry kind="lib" path="library/mp3spi1.9.4.jar"/>
-	<classpathentry kind="lib" path="library/org-jaudiolibs-audioservers-jack.jar"/>
-	<classpathentry kind="lib" path="library/org-jaudiolibs-audioservers-javasound.jar"/>
-	<classpathentry kind="lib" path="library/org-jaudiolibs-audioservers.jar"/>
-	<classpathentry kind="lib" path="library/org-jaudiolibs-jnajack.jar"/>
-	<classpathentry kind="lib" path="library/tools.jar"/>
-	<classpathentry kind="lib" path="library/tritonus_aos-0.3.6.jar"/>
-	<classpathentry kind="lib" path="library/tritonus_share.jar"/>
+	<classpathentry kind="lib" path="dependencies/beads.jar"/>
+	<classpathentry kind="lib" path="dependencies/beads-io.jar"/>
+	<classpathentry kind="lib" path="dependencies/jarjar-1.0.jar"/>
+	<classpathentry kind="lib" path="dependencies/jl1.0.1.jar"/>
+	<classpathentry kind="lib" path="dependencies/jna.jar"/>
+	<classpathentry kind="lib" path="dependencies/mp3spi1.9.4.jar"/>
+	<classpathentry kind="lib" path="dependencies/org-jaudiolibs-audioservers-jack.jar"/>
+	<classpathentry kind="lib" path="dependencies/org-jaudiolibs-audioservers-javasound.jar"/>
+	<classpathentry kind="lib" path="dependencies/org-jaudiolibs-audioservers.jar"/>
+	<classpathentry kind="lib" path="dependencies/org-jaudiolibs-jnajack.jar"/>
+	<classpathentry kind="lib" path="dependencies/tools.jar"/>
+	<classpathentry kind="lib" path="dependencies/tritonus_aos-0.3.6.jar"/>
+	<classpathentry kind="lib" path="dependencies/tritonus_share.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/src/beads_main/net/beadsproject/beads/core/AudioContext.java
+++ b/src/beads_main/net/beadsproject/beads/core/AudioContext.java
@@ -295,8 +295,11 @@ public class AudioContext {
 			while (out != null && !stopped) {
 				bufStoreIndex = 0;
 				Arrays.fill(zeroBuf, 0f);
-				if (!out.isPaused())
+				if (!out.isPaused()) {
+					sendBeforeFrameMessages();
 					out.update();
+					sendAfterFrameMessages();
+				}
 				timeStep++;
 				if (logTime && timeStep % 100 == 0) {
 					System.out.println(samplesToMs(timeStep


### PR DESCRIPTION
There are two commits.

The first fixes the Eclipse classpath to look in "dependencies" rather
than "library" for the depended-on jarfiles.

The second calls the sendBeforeFrameMessages() and
sendAfterFrameMessages() methods in runNonRealTime, to ensure
that pre- and post-frame hooks are invoked when
running in non-real-time mode.