### PR TITLE
Adding maven install support for beads

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,300 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ======================================================================
+     Beads - a computer music and sound art library for Java.
+     ====================================================================== -->
+<project name="beads" default="default">
+	<description>
+    	Beads - a computer music and sound art library for Java.
+    </description>
+    <!-- main director -->
+    <property name="beadsdir" value="." />
+	<!-- directory from which to copy package related data (such as readmes, etc.) -->
+	<property name="packages" value="${beadsdir}/packages" />
+	<!-- directory to build packages and set up zips and docs for export -->
+	<property name="build" value="${beadsdir}/build" />
+    <!-- directory where dependencies live -->
+    <property name="depsdir" value="${beadsdir}/dependencies" />
+	<!-- stuff that lasts a very short time (a tmp build folder) -->
+	<property name="tmp" value="${build}/tmp" />
+	<!-- an export folder -->
+	<property name="exportdir" value="${tmp}/export">
+	</property>
+	<property name="ant.build.javac.target" value="1.6">
+	</property>
+	<property name="ant.build.javac.source" value="1.6">
+	</property>
+	<property name="ant.build.javac.compiler" value="javac1.6">
+	</property>
+	<!-- maven related extras: -->
+	<property name="src" location="src" />
+	<property name="dist" location="dist" />
+	<!-- we already have build defined -->
+	<!-- Maven coordinates -->
+	<property name="groupId" value="net.beads" />
+	<property name="artifactId" value="beads" />
+	<property name="version" value="1.01-snapshot" />
+	<!-- define artifacts' name, which follows the convention of Maven -->
+	<property name="jar" value="${dist}/lib/${artifactId}-${version}.jar" />
+	<property name="javadoc-jar" value="${dist}/lib/${artifactId}-${version}-javadoc.jar" />
+	<property name="sources-jar" value="${dist}/lib/${artifactId}-${version}-sources.jar" />
+	<!-- end maven related extras -->
+	<tstamp>
+		<format property="TODAY" pattern="yyyyMMdd" />
+	</tstamp>
+
+	<!-- =================================
+          target: default
+         ================================= -->
+	<target name="default" description="combine compile main and doc main" depends="compile main">
+	</target>
+
+	<!-- =================================
+          target: compile main
+         ================================= -->
+	<target name="compile main" description="compiles main beads project to beads.jar" depends="doc main">
+		<!-- BUILD ALL CLASS FILES (THEY ARE TEMPORARY) -->
+		<property name="buildmain" value="${tmp}/main" />
+		<property name="buildio" value="${tmp}/io" />
+		<mkdir dir="${buildmain}" />
+		<mkdir dir="${buildio}" />
+		<!-- MAIN BEADS SRC -->
+		<javac srcdir="${beadsdir}/src/beads_main" destdir="${buildmain}" debug="off" compiler="javac1.6">
+			<compilerarg value="-Xlint:unchecked" />
+		</javac>
+		<!-- IO SRC -->
+		<javac srcdir="${beadsdir}/src/beads_io" destdir="${buildio}" debug="off" compiler="javac1.6">
+			<classpath>
+				<pathelement location="${depsdir}/tritonus_share.jar" />
+				<pathelement location="${depsdir}/org-jaudiolibs-audioservers.jar" />
+				<pathelement location="${depsdir}/org-jaudiolibs-audioservers-jack.jar" />
+				<pathelement location="${depsdir}/org-jaudiolibs-audioservers-javasound.jar" />
+				<pathelement location="${buildmain}" />
+			</classpath>
+			<compilerarg value="-Xlint:unchecked" />
+		</javac>
+
+		<!-- BUILD THE STANDARD JAVA VERSION OF BEADS PACKAGE (ALSO ECLIPSE PROJECT) -->
+
+		<property name="beadsoutdir" value="${build}/beads" />
+		<property name="libdir" value="${beadsoutdir}/library" />
+		<mkdir dir="${libdir}" />
+
+
+<!--        <jar jarfile="${libdir}/beads-main.jar" basedir="${buildmain}" />
+        <jar jarfile="${libdir}/beads-io.jar" basedir="${buildio}" />
+-->
+        <taskdef name="jarjar" classname="com.tonicsystems.jarjar.JarJarTask" classpath="${depsdir}/jarjar-1.0.jar" />
+
+        <!-- Can we jar the jars together? -->
+        <jarjar jarfile="${libdir}/beads.jar">
+            <fileset dir="${buildmain}" />
+            <fileset dir="${buildio}" />
+            <zipfileset src="${depsdir}/jl1.0.1.jar" />
+            <zipfileset src="${depsdir}/mp3spi1.9.4.jar" />
+            <zipfileset src="${depsdir}/tritonus_share.jar" />
+            <zipfileset src="${depsdir}/org-jaudiolibs-audioservers.jar" />
+            <zipfileset src="${depsdir}/org-jaudiolibs-audioservers-jack.jar" />
+            <zipfileset src="${depsdir}/org-jaudiolibs-audioservers-javasound.jar" />
+            <zipfileset src="${depsdir}/org-jaudiolibs-jnajack.jar" />
+            <zipfileset src="${depsdir}/jna.jar" />
+            <zipfileset src="${depsdir}/tools.jar" />
+            <zipfileset src="${depsdir}/tritonus_aos-0.3.6.jar" />
+        </jarjar>
+
+<!--
+		<copy file="${depsdir}/jl1.0.1.jar" toFile="${libdir}/jl1.0.1.jar" />
+		<copy file="${depsdir}/mp3spi1.9.4.jar" toFile="${libdir}/mp3spi1.9.4.jar" />
+		<copy file="${depsdir}/tritonus_share.jar" toFile="${libdir}/tritonus_share.jar" />
+		<copy file="${depsdir}/org-jaudiolibs-audioservers.jar" toFile="${libdir}/org-jaudiolibs-audioservers.jar" />
+		<copy file="${depsdir}/org-jaudiolibs-audioservers-jack.jar" toFile="${libdir}/org-jaudiolibs-audioservers-jack.jar" />
+		<copy file="${depsdir}/org-jaudiolibs-audioservers-javasound.jar" toFile="${libdir}/org-jaudiolibs-audioservers-javasound.jar" />
+		<copy file="${depsdir}/org-jaudiolibs-jnajack.jar" toFile="${libdir}/org-jaudiolibs-jnajack.jar" />
+		<copy file="${depsdir}/jarjar-1.0.jar" toFile="${libdir}/jarjar-1.0.jar" />
+		<copy file="${depsdir}/jna.jar" toFile="${libdir}/jna.jar" />
+		<copy file="${depsdir}/tools.jar" toFile="${libdir}/tools.jar" />
+		<copy file="${depsdir}/tritonus_aos-0.3.6.jar" toFile="${libdir}/tritonus_aos-0.3.6.jar" />
+
+-->
+
+
+		<!-- tutorial and audio files -->
+		<copy todir="${beadsoutdir}/tutorial">
+			<fileset dir="../packages/Beads/beads_tutorial" />
+		</copy>
+		<delete dir="${beadsoutdir}/tutorial/.svn" />
+		<copy todir="${beadsoutdir}/audio">
+			<fileset dir="../audio" />
+		</copy>
+		<delete dir="${beadsoutdir}/audio/.svn" />
+		<!-- copy documentation -->
+		<mkdir dir="${beadsoutdir}/doc" />
+		<copy todir="${beadsoutdir}/doc">
+			<fileset dir="${build}/doc" />
+		</copy>
+		<!-- copy src -->
+		<copy todir="${beadsoutdir}/src">
+			<fileset dir="${beadsdir}/src" />
+		</copy>
+		<!-- copy readme and project files -->
+		<copy file="${packages}/Beads/README.txt" toDir="${beadsoutdir}/" />
+		<copy file="${packages}/release_notes.txt" toDir="${beadsoutdir}/" />
+		<!-- copy eclipse project files -->
+		<copy file="${packages}/Beads/.project" toDir="${beadsoutdir}/" />
+		<copy file="${packages}/Beads/.classpath" toDir="${beadsoutdir}/" />
+
+		<!-- BUILD THE PROCESSING VERSION OF BEADS PACKAGE -->
+
+		<!-- Following the guidelines here: http://dev.processing.org/libraries/basics.html  -->
+		<property name="processing" location="${build}/beads_processing" />
+		<property name="proclib" location="${processing}/beads/library" />
+		<mkdir dir="${proclib}" />
+		<jarjar jarfile="${proclib}/beads.jar">
+			<fileset dir="${buildmain}" />
+			<fileset dir="${buildio}" />
+			<rule pattern="net.beadsproject.beads.*.*.**" result="beads.@3" />
+			<rule pattern="net.beadsproject.beads.*.**" result="beads.@2" />
+            <zipfileset src="${depsdir}/jl1.0.1.jar" />
+            <zipfileset src="${depsdir}/mp3spi1.9.4.jar" />
+            <zipfileset src="${depsdir}/tritonus_share.jar" />
+            <zipfileset src="${depsdir}/org-jaudiolibs-audioservers.jar" />
+            <zipfileset src="${depsdir}/org-jaudiolibs-audioservers-jack.jar" />
+            <zipfileset src="${depsdir}/org-jaudiolibs-audioservers-javasound.jar" />
+            <zipfileset src="${depsdir}/org-jaudiolibs-jnajack.jar" />
+            <zipfileset src="${depsdir}/jna.jar" />
+            <zipfileset src="${depsdir}/tools.jar" />
+            <zipfileset src="${depsdir}/tritonus_aos-0.3.6.jar" />
+		</jarjar>
+
+<!--
+		<copy file="${depsdir}/jl1.0.1.jar" toFile="${proclib}/jl1.0.1.jar" />
+		<copy file="${depsdir}/mp3spi1.9.4.jar" toFile="${proclib}/mp3spi1.9.4.jar" />
+		<copy file="${depsdir}/tritonus_share.jar" toFile="${proclib}/tritonus_share.jar" />
+		<copy file="${depsdir}/org-jaudiolibs-audioservers.jar" toFile="${proclib}/org-jaudiolibs-audioservers.jar" />
+		<copy file="${depsdir}/org-jaudiolibs-audioservers-jack.jar" toFile="${proclib}/org-jaudiolibs-audioservers-jack.jar" />
+		<copy file="${depsdir}/org-jaudiolibs-audioservers-javasound.jar" toFile="${proclib}/org-jaudiolibs-audioservers-javasound.jar" />
+		<copy file="${depsdir}/org-jaudiolibs-jnajack.jar" toFile="${proclib}/org-jaudiolibs-jnajack.jar" />
+		<copy file="${depsdir}/jarjar-1.0.jar" toFile="${proclib}/jarjar-1.0.jar" />
+		<copy file="${depsdir}/jna.jar" toFile="${proclib}/jna.jar" />
+		<copy file="${depsdir}/tools.jar" toFile="${proclib}/tools.jar" />
+		<copy file="${depsdir}/tritonus_aos-0.3.6.jar" toFile="${proclib}/tritonus_aos-0.3.6.jar" />
+
+-->
+		<!-- copy tutorials into an "examples" directory -->
+		<copy todir="${processing}/beads/examples">
+			<fileset dir="${packages}/Processing/tutorial" />
+		</copy>
+		<delete dir="${processing}/beads/tutorial/.svn" />
+		<!-- copy documentation to a "reference" directory -->
+		<copy todir="${processing}/beads/reference">
+			<fileset dir="${build}/doc" />
+		</copy>
+		<!-- copy src -->
+		<copy todir="${processing}/beads/src">
+			<fileset dir="${beadsdir}/src" />
+		</copy>
+		<!-- copy readme and notes -->
+		<copy file="${packages}/Processing/README.txt" toDir="${processing}/" />
+		<copy file="${packages}/Processing/library.properties" toDir="${processing}/beads/" />
+		<copy file="${packages}/release_notes.txt" toDir="${processing}/beads/" />
+
+	</target>
+
+
+	<!-- =================================
+          target: clean
+         ================================= -->
+	<target name="clean" description="clean up">
+		<delete dir="${build}/beads" />
+		<delete dir="${build}/doc" />
+		<delete dir="${build}/beads_processing" />
+		<delete dir="${build}/tmp" />
+		<delete dir="${dist}" />
+	</target>
+
+	<!-- =================================
+          target: doc main
+         ================================= -->
+	<target name="doc main" description="generate docs for main" depends="init">
+		<javadoc sourcepath="${beadsdir}/src/beads_main" destdir="${build}/doc">
+			<tag name="beads.category" enabled="False" />
+			<classpath>
+				<pathelement location="${depsdir}/tritonus_share.jar" />
+			</classpath>
+		</javadoc>
+		<delete dir="${tmp}" />
+	</target>
+
+	<!-- maven related targets: -->
+	<target name="init" depends="clean">
+		<mkdir dir="${build}" />
+		<mkdir dir="${dist}/lib" />
+	</target>
+
+	<target name="compile" depends="init">
+	  <!--<javac srcdir="${src}" destdir="${build}" />-->
+        <property name="buildmain" value="${tmp}/main" />
+        <property name="buildio" value="${tmp}/io" />
+        <mkdir dir="${buildmain}" />
+        <mkdir dir="${buildio}" />
+
+        <!-- MAIN BEADS SRC -->
+        <javac srcdir="${beadsdir}/src/beads_main" destdir="${buildmain}" debug="off" compiler="javac1.6">
+            <compilerarg value="-Xlint:unchecked" />
+        </javac>
+        <!-- IO SRC -->
+        <javac srcdir="${beadsdir}/src/beads_io" destdir="${buildio}" debug="off" compiler="javac1.6">
+            <classpath>
+                <pathelement location="${depsdir}/tritonus_share.jar" />
+                <pathelement location="${depsdir}/org-jaudiolibs-audioservers.jar" />
+                <pathelement location="${depsdir}/org-jaudiolibs-audioservers-jack.jar" />
+                <pathelement location="${depsdir}/org-jaudiolibs-audioservers-javasound.jar" />
+                <pathelement location="${buildmain}" />
+            </classpath>
+            <compilerarg value="-Xlint:unchecked" />
+        </javac>
+	</target>
+
+	<target name="jar" depends="compile">
+	  <!-- build the main artifact -->
+	  <!-- <jar jarfile="${jar}" basedir="${build}" /> -->
+
+
+		<taskdef name="jarjar" classname="com.tonicsystems.jarjar.JarJarTask" classpath="${depsdir}/jarjar-1.0.jar" />
+
+		<!-- Can we jar the jars together? -->
+		<jarjar jarfile="${jar}">
+				<fileset dir="${buildmain}" />
+                <fileset dir="${buildio}" />
+				<zipfileset src="${depsdir}/jl1.0.1.jar" />
+				<zipfileset src="${depsdir}/mp3spi1.9.4.jar" />
+				<zipfileset src="${depsdir}/tritonus_share.jar" />
+				<zipfileset src="${depsdir}/org-jaudiolibs-audioservers.jar" />
+				<zipfileset src="${depsdir}/org-jaudiolibs-audioservers-jack.jar" />
+				<zipfileset src="${depsdir}/org-jaudiolibs-audioservers-javasound.jar" />
+				<zipfileset src="${depsdir}/org-jaudiolibs-jnajack.jar" />
+				<zipfileset src="${depsdir}/jna.jar" />
+				<zipfileset src="${depsdir}/tools.jar" />
+				<zipfileset src="${depsdir}/tritonus_aos-0.3.6.jar" />
+		</jarjar>
+	</target>
+
+	<target name="dist" depends="jar">
+	  <!-- build the javadoc jar -->
+	  <!--<javadoc sourcepath="${src}" destdir="${dist}/javadoc" />-->
+        <javadoc sourcepath="${beadsdir}/src/beads_main" destdir="${dist}/javadoc">
+            <tag name="beads.category" enabled="False" />
+            <classpath>
+                <pathelement location="${depsdir}/tritonus_share.jar" />
+            </classpath>
+        </javadoc>
+	  <jar jarfile="${javadoc-jar}">
+	    <fileset dir="${dist}/javadoc" />
+	  </jar>
+
+	  <!-- build the sources jar -->
+	  <jar jarfile="${sources-jar}">
+	    <fileset dir="${src}" />
+	  </jar>
+	</target>
+	<!-- end maven related targets -->
+</project>

--- a/build.xml
+++ b/build.xml
@@ -119,11 +119,11 @@
 
 		<!-- tutorial and audio files -->
 		<copy todir="${beadsoutdir}/tutorial">
-			<fileset dir="../packages/Beads/beads_tutorial" />
+			<fileset dir="./packages/Beads/beads_tutorial" />
 		</copy>
 		<delete dir="${beadsoutdir}/tutorial/.svn" />
 		<copy todir="${beadsoutdir}/audio">
-			<fileset dir="../audio" />
+			<fileset dir="./audio" />
 		</copy>
 		<delete dir="${beadsoutdir}/audio/.svn" />
 		<!-- copy documentation -->

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,5 +1,0 @@
-/beads
-/beads_processing
-/doc
-/ref
-/tmp

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.samgwise</groupId>
+    <artifactId>beads</artifactId>
+    <version>1.01-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <target>
+                                <ant antfile="build.xml" target="default" />
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>2.3.1</version>
+                <executions>
+                    <execution>
+                        <id>install-library</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <configuration>
+                            <groupId>com.github.samgwise</groupId>
+                            <artifactId>beads</artifactId>
+                            <version>${project.version}</version>
+                            <file>build/lib/beads.jar</file>
+                            <packaging>zip</packaging>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
                             <groupId>com.github.samgwise</groupId>
                             <artifactId>beads</artifactId>
                             <version>${project.version}</version>
-                            <file>build/libs/beads.jar</file>
+                            <file>build/beads/library/beads.jar</file>
                             <packaging>jar</packaging>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
                             <goal>install-file</goal>
                         </goals>
                         <configuration>
-                            <groupId>com.github.samgwise</groupId>
+                            <groupId>net.beadsproject</groupId>
                             <artifactId>beads</artifactId>
                             <version>${project.version}</version>
                             <file>build/beads/library/beads.jar</file>

--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,19 @@
         <plugins>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
+                <version>1.6</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.sun</groupId>
+                        <artifactId>tools</artifactId>
+                        <version>1.5.0</version>
+                        <scope>system</scope>
+                        <systemPath>${java.home}/../lib/tools.jar</systemPath>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
-                        <phase>process-resources</phase>
+                        <phase>compile</phase>
                         <configuration>
                             <target>
                                 <ant antfile="build.xml" target="default" />
@@ -43,8 +52,8 @@
                             <groupId>com.github.samgwise</groupId>
                             <artifactId>beads</artifactId>
                             <version>${project.version}</version>
-                            <file>build/lib/beads.jar</file>
-                            <packaging>zip</packaging>
+                            <file>build/libs/beads.jar</file>
+                            <packaging>jar</packaging>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
By Adding a pom.xml which runs an updated ant script we can enable use of maven install to local. This feature allows the use of services such as jitpack.io for pulling beads in as a project dependency.