### PR TITLE
Removing println statement in constructor

### DIFF
--- a/src/beads_main/java/net/beadsproject/beads/ugens/WavePlayer.java
+++ b/src/beads_main/java/net/beadsproject/beads/ugens/WavePlayer.java
@@ -52,7 +52,6 @@ public class WavePlayer extends UGen {
 		super(context, 1);
 		this.buffer = buffer;
 		phase = 0;
-		System.out.println(context);
 		one_over_sr = 1f / context.getSampleRate();
 	}
 


### PR DESCRIPTION
It seems a `println` statement was accidentally left in the `WavePlayer` constructor. This change removes it.